### PR TITLE
Pivot site from consulting to education (course-led)

### DIFF
--- a/_old_services.qmd
+++ b/_old_services.qmd
@@ -1,0 +1,72 @@
+---
+title: "Services"
+sidebar: false
+toc: false
+image: cover.png
+aliases: ["hire/", "hire"]
+repo-actions: false
+search: false
+css: services.css
+---
+
+We help teams already shipping AI / LLM features build eval systems so they can ship faster, reduce manual QA, and catch failures before users do.
+
+## Is this you?
+
+- Your team spends most of their time manually QA-ing your AI features, and you know it won't scale.
+- You're scared to ship AI changes because you don't trust your metrics.
+- You've hired smart people, bought tools, and you're still guessing whether your AI is getting better or worse.
+
+## We Want You to "Fire Us"
+
+**We don't want you to have a long-term dependency on us.** We're not here to pitch you new frameworks or expensive infrastructure. We're here to teach you methods to experiment faster and systematically improve your systems.
+
+We don't chase recurring revenue or sell maintenance contracts. That creates perverse incentives. Instead, we work alongside your team and transfer knowledge so you can be successful.
+
+---
+
+## Services
+
+### Education
+
+Our course [AI Evals For Engineers & PMs](https://maven.com/parlance-labs/evals){target="_blank"} has trained over 4,000 students from 500+ companies on [AI product evals](https://hamel.dev/blog/posts/evals-faq/){target="_blank"}.
+
+### Advisory
+
+We partner with you for roughly 8 weeks to:
+
+- Map and prioritize errors in your product
+- Design application-specific evals
+- Audit your current metrics and experimentation process
+- Identify bottlenecks blocking iteration
+
+You get written artifacts: eval specifications, metrics and a roadmaps your team can execute.
+
+**Minimum engagement starts at $285,500** for an 8-week sprint. We take on a limited number of engagements per quarter. If this is out of your budget, check out our [AI Evals course](https://evals.info){target="_blank"}.
+
+**Our guarantee:** If we can't deliver in 8 weeks for any reason (including if your team's bandwidth shifts), we keep working at no extra cost until we do.
+
+---
+
+:::{.cta-section .cta-prominent}
+<div class="cta-buttons">
+<div class="cta-option">
+[Enroll in Course](https://evals.info){.cta-button-primary role="button" target="_blank"}
+<span class="cta-subtext">$3,750 per seat</span>
+</div>
+<div class="cta-option">
+[Apply for Advisory](https://form.typeform.com/to/M8f89mlM){.cta-button-secondary role="button" target="_blank"}
+<span class="cta-subtext">Starting at $285,500</span>
+</div>
+</div>
+:::
+
+---
+
+## Testimonials
+
+See what our clients and students say on our [homepage](index.qmd#what-our-clients-students-say). References available upon request.
+
+---
+
+<p class="cta-adhoc">Need a quick consultation? [Book a 1-hour session with Hamel](https://calendly.com/hamel-husain/consultation){target="_blank"}</p>

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -36,11 +36,11 @@ website:
     collapse-below: sm
     logo: b.png
     left:
-    - text: Services
+    - text: Course
       file: services.qmd
     - text: Team
       file: team.qmd
-    - text: Education
+    - text: Resources
       file: education/
   sidebar:
     - title: Resources

--- a/index.qmd
+++ b/index.qmd
@@ -12,7 +12,7 @@ image: cover.png
 
 # Parlance Labs
 
-Practical consulting that improves your AI.
+Learn to build AI that works in production.
 :::
 
 ## What We Do
@@ -21,7 +21,7 @@ Practical consulting that improves your AI.
 
 <div class="value-card">
 <span class="value-number">01</span>
-<p>Build <strong>evaluation systems</strong> that identify exactly what's broken and what to fix next.</p>
+<p>Learn to build <strong>evaluation systems</strong> that identify exactly what's broken and what to fix next.</p>
 </div>
 
 <div class="value-card">
@@ -31,14 +31,14 @@ Practical consulting that improves your AI.
 
 <div class="value-card">
 <span class="value-number">03</span>
-<p><strong>Ship better AI faster</strong>—then keep improving without us.</p>
+<p><strong>Ship better AI faster</strong>, and keep improving on your own.</p>
 </div>
 
 :::
 
 :::{.logo-carousel-section}
 
-<div class="carousel-heading">We've worked with over 500 of the world's top companies</div>
+<div class="carousel-heading">4,500 Engineers and PMs from the world's top companies have taken our course</div>
 
 <div class="logo-track logo-track-row-1">
 <div class="logo-item"><img src="logos/google.png" alt="Google"></div>
@@ -123,12 +123,12 @@ Practical consulting that improves your AI.
 :::
 
 :::{.cta-section}
-[Work With Us](./services.qmd){.cta-button role="button"}
+[Explore the course](./services.qmd){.cta-button role="button"}
 :::
 
 :::{.wall-of-love}
 
-## What Our Clients & Students Say
+## What Our Students Say
 
 <iframe id='testimonialto-c32618a4-482d-4fbe-9b83-bd5037e5b3e9' src="https://embed-v2.testimonial.to/w/ai-mastery-for-busy-executives?id=c32618a4-482d-4fbe-9b83-bd5037e5b3e9" frameborder="0" scrolling="no" width="100%" height="800px"></iframe>
 
@@ -137,5 +137,5 @@ Practical consulting that improves your AI.
 :::
 
 :::{.cta-section}
-[Work With Us](./services.qmd){.cta-button role="button"}
+[Explore the course](./services.qmd){.cta-button role="button"}
 :::

--- a/services.css
+++ b/services.css
@@ -16,7 +16,7 @@
   background: var(--pl-accent, #38bdf8);
   border: 1px solid var(--pl-accent, #38bdf8);
   color: #0f1114 !important;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   font-weight: 600;
   font-size: 1rem;
   padding: 0.875rem 2.5rem;
@@ -63,7 +63,7 @@
   background: transparent;
   border: 1px solid var(--pl-accent, #38bdf8);
   color: var(--pl-accent, #38bdf8) !important;
-  font-family: 'Space Grotesk', sans-serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   font-weight: 500;
   font-size: 1rem;
   padding: 0.875rem 2rem;
@@ -96,6 +96,41 @@
 
 .cta-adhoc a:hover {
   color: var(--pl-accent, #38bdf8);
+}
+
+/* Hero CTA - tighter spacing so the proof bar sits close beneath it */
+.cta-hero {
+  padding: 0.5rem 0 0;
+}
+
+.cta-hero .cta-option p {
+  margin-bottom: 0;
+}
+
+/* Proof bar under the hero */
+.proof-bar {
+  text-align: center;
+  margin: 1rem 0 0.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--pl-text-secondary, #d4d4d8);
+}
+
+/* Secondary link beneath the bottom CTA - visible, not buried */
+.cta-secondary-link {
+  text-align: center;
+  margin: 1.1rem 0 0;
+  font-size: 0.95rem;
+  color: var(--pl-text-secondary, #d4d4d8);
+}
+
+.cta-secondary-link a {
+  color: var(--pl-accent, #38bdf8);
+  font-weight: 500;
+}
+
+.cta-secondary-link a:hover {
+  text-decoration: underline;
 }
 
 /* Responsive - stack on mobile */

--- a/services.qmd
+++ b/services.qmd
@@ -1,5 +1,6 @@
 ---
-title: "Services"
+title: "Build, Evaluate, and Improve AI That Works in Production"
+subtitle: "The most field-tested evals course available. We've refined it over a year of cohorts with 4,500+ engineers and PMs from teams like OpenAI, Google, Meta, and Amazon."
 sidebar: false
 toc: false
 image: cover.png
@@ -9,64 +10,52 @@ search: false
 css: services.css
 ---
 
-We help teams already shipping AI / LLM features build eval systems so they can ship faster, reduce manual QA, and catch failures before users do.
-
-## Is this you?
-
-- Your team spends most of their time manually QA-ing your AI features, and you know it won't scale.
-- You're scared to ship AI changes because you don't trust your metrics.
-- You've hired smart people, bought tools, and you're still guessing whether your AI is getting better or worse.
-
-## We Want You to "Fire Us"
-
-**We don't want you to have a long-term dependency on us.** We're not here to pitch you new frameworks or expensive infrastructure. We're here to teach you methods to experiment faster and systematically improve your systems.
-
-We don't chase recurring revenue or sell maintenance contracts. That creates perverse incentives. Instead, we work alongside your team and transfer knowledge so you can be successful.
-
----
-
-## Services
-
-### Education
-
-Our course [AI Evals For Engineers & PMs](https://maven.com/parlance-labs/evals){target="_blank"} has trained over 4,000 students from 500+ companies on [AI product evals](https://hamel.dev/blog/posts/evals-faq/){target="_blank"}.
-
-### Advisory
-
-We partner with you for roughly 8 weeks to:
-
-- Map and prioritize errors in your product
-- Design application-specific evals
-- Audit your current metrics and experimentation process
-- Identify bottlenecks blocking iteration
-
-You get written artifacts: eval specifications, metrics and a roadmaps your team can execute.
-
-**Minimum engagement starts at $285,500** for an 8-week sprint. We take on a limited number of engagements per quarter. If this is out of your budget, check out our [AI Evals course](https://evals.info){target="_blank"}.
-
-**Our guarantee:** If we can't deliver in 8 weeks for any reason (including if your team's bandwidth shifts), we keep working at no extra cost until we do.
-
----
-
-:::{.cta-section .cta-prominent}
-<div class="cta-buttons">
+:::{.cta-section .cta-hero}
 <div class="cta-option">
-[Enroll in Course](https://evals.info){.cta-button-primary role="button" target="_blank"}
-<span class="cta-subtext">$3,750 per seat</span>
-</div>
-<div class="cta-option">
-[Apply for Advisory](https://form.typeform.com/to/M8f89mlM){.cta-button-secondary role="button" target="_blank"}
-<span class="cta-subtext">Starting at $285,500</span>
-</div>
+[See next cohort dates &amp; enroll](https://maven.com/parlance-labs/evals?promoCode=evals-info-url){.cta-button-primary role="button" target="_blank"}
+<span class="cta-subtext">AI Evals For Engineers &amp; PMs · $3,150</span>
 </div>
 :::
 
+<p class="proof-bar">4.7/5 from 879 reviews · Featured in Lenny's List</p>
+
+## Is this you?
+
+- You're spot-checking AI outputs by hand, and you know it won't scale.
+- You're scared to ship a prompt or model change because you don't trust your metrics.
+- Leadership keeps asking "is this actually better?" and you don't have an answer you trust.
+- You've hired smart people and bought tools, and you're still guessing whether your AI is getting better or worse.
+
+If so, you're in the right place. We teach the system for fixing it.
+
+## The course: AI Evals For Engineers & PMs
+
+Build a real AI agent, find where it breaks, and improve it with evals you can trust, working the full loop hands-on. Over the cohort you will:
+
+- Replace random spot-checking with a repeatable way to read traces and find failures.
+- Design and validate LLM-as-judge and code-based evaluators that match expert judgment.
+- Wire evals into CI/CD so prompt, model, and tool changes get checked before they ship.
+- Run experiments that raise accuracy and cut cost, and prove which change moved the metric.
+
+You learn it live from Hamel Husain and Shreya Shankar, and keep lifetime access to all recordings and materials, a 150+ page course reader, 10+ hours of office hours, a private Discord community, and a seat in every future cohort.
+
+**Backed by the Maven Guarantee:** a full refund through the halfway point of the cohort, no questions asked.
+
+## We build self-sufficient teams, not dependence
+
+Most AI programs are thinly veiled retainers. They keep you dependent so you keep paying. We do the opposite.
+
+The course is designed to transfer the eval system into your team's head and codebase, so you can run it without us. You get lifetime access to the materials and can retake future cohorts, so you are never renting a playbook.
+
+Our incentive is simple: make you so good you don't need us.
+
 ---
 
-## Testimonials
+:::{.cta-section}
+<div class="cta-option">
+[See next cohort dates &amp; enroll](https://maven.com/parlance-labs/evals?promoCode=evals-info-url){.cta-button-primary role="button" target="_blank"}
+<span class="cta-subtext">AI Evals For Engineers &amp; PMs · $3,150</span>
+</div>
 
-See what our clients and students say on our [homepage](index.qmd#what-our-clients-students-say). References available upon request.
-
----
-
-<p class="cta-adhoc">Need a quick consultation? [Book a 1-hour session with Hamel](https://calendly.com/hamel-husain/consultation){target="_blank"}</p>
+<p class="cta-secondary-link">Already taken the course and shipping AI in production? [Join the Advanced AI Engineering Community](https://www.skool.com/ai-eng/about){target="_blank"}</p>
+:::

--- a/team.qmd
+++ b/team.qmd
@@ -11,16 +11,10 @@ search: false
 
 ![](images/hamel.png){width=70 style="float:left"} 
 
-[Hamel Husain](https://hamel.dev){target="_blank"} is a machine learning engineer with over 25 years of experience. He has worked with innovative companies such as Airbnb and GitHub, which included <a href="https://openai.com/index/introducing-text-and-code-embeddings#:~:text=models%20on%20the-,CodeSearchNet,),-evaluation%20suite%20where" target="_blank">early LLM research used by OpenAI</a> for code understanding. He has also led and contributed to numerous popular [open-source machine-learning tools](https://hamel.dev/oss/opensource.html){target="_blank"}.
+[Hamel Husain](https://hamel.dev){target="_blank"} is a machine learning engineer and educator with over 25 years of experience. He has worked with innovative companies such as Airbnb and GitHub, which included <a href="https://openai.com/index/introducing-text-and-code-embeddings#:~:text=models%20on%20the-,CodeSearchNet,),-evaluation%20suite%20where" target="_blank">early LLM research used by OpenAI</a> for code understanding. He has also led and contributed to numerous popular [open-source machine-learning tools](https://hamel.dev/oss/opensource.html){target="_blank"}.
 
 ## Shreya Shankar
 
 ![](images/shreya.jpeg){width=70 style="float:left"}
 
-[Shreya](https://www.sh-reya.com/){target="_blank"} is a leading researcher on applied ML and AI systems.  She has led extensive research on human-computer interaction for low-code tools to program complex LLM workflows including evals, monitoring and fine-tuning.  Her research has been adopted widely and is incorporated into many commercial LLM tools such as Langsmith, Autoblocks, Parea, and more. 
-
-## John Berryman
-
-![](images/jnbrymn.png){width=70 style="float:left"} 
-
-[John](https://arcturus-labs.com/){target="_blank"} has worked in technology since 2012. The first half of his career was spent building search applications. John helped build next-generation search for the U.S. Patent Office, built Eventbrite's search and recommendation platforms, built GitHub's code search, and co-authored a book – Relevant Search (Manning). While at GitHub, John moved into Data Science and then into Machine Learning with GitHub's Copilot code completions and chat products. John is currently co-authoring an O'Reilly book for LLM application development.
+[Shreya](https://www.sh-reya.com/){target="_blank"} is a leading researcher on applied ML and AI systems.  She has led extensive research on human-computer interaction for low-code tools to program complex LLM workflows including evals, monitoring and fine-tuning.  Her research has been adopted widely and is incorporated into many commercial LLM tools such as Langsmith, Autoblocks, Parea, and more.


### PR DESCRIPTION
Repositions the site around the **AI Evals course** and removes the consulting/advisory offer. Reviewed against the ACQ (Hormozi) advisor: course-led with one quiet alumni link to the community.

## Course page (`services.qmd`)
- Rebuilt the old consulting "Services" page into a course-led landing page: new headline (*"Build, Evaluate, and Improve AI That Works in Production"*), readable social-proof subhead, proof line (4.7/5 · Lenny's List), refined "Is this you?" (incl. a leadership pain bullet), course details + Maven Guarantee, "self-sufficient teams" reframe (replaces the old "we don't chase recurring revenue" line), enroll CTAs top + bottom, and a visible alumni link to the **Advanced AI Engineering Community**.
- Removed: advisory offer, $285,500 sprint, Typeform + Calendly CTAs.
- **No broken links:** URL stays `/services.html`; `/hire` + `/hire/` aliases preserved. Old page archived as `_old_services.qmd` (underscore = not rendered).

## Homepage (`index.qmd`)
- Tagline → *"Learn to build AI that works in production."*
- Three "What We Do" cards reframed as course outcomes (and em dash removed).
- Logo-wall heading → *"4,500 Engineers and PMs from the world's top companies have taken our course."*
- CTAs → *"Explore the course"*; testimonials heading → *"What Our Students Say."*

## Nav & team
- `_quarto.yml`: navbar **Services → Course**, **Education → Resources**.
- `team.qmd`: Hamel bio → *"engineer and educator"*; removed John Berryman.

## Styling (`services.css`)
- Hero/proof/secondary-link styles; fixed CTA button font (requested `Space Grotesk`, never loaded) → **Inter**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/parlance-labs/website/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->